### PR TITLE
Add skeleton command test case

### DIFF
--- a/src/Skeleton/MakeSkeletonCommand.php
+++ b/src/Skeleton/MakeSkeletonCommand.php
@@ -118,9 +118,13 @@ class MakeSkeletonCommand extends Commander
         $this->filesystem->put($readme, str_replace(
             [
                 "DummyPackageName",
+                "DummyNamespace",
+                "DummyClassName",
             ],
             [
                 $this->getQualifiedPackageName($vendor, $package),
+                $this->getQualifiedNamespace($vendor, $package),
+                $this->getQualifiedClassName($package),
             ],
             $this->filesystem->get($readme)
         ));

--- a/src/stubs/README.md
+++ b/src/stubs/README.md
@@ -22,7 +22,7 @@ DummyNamespace\DummyClassNameServiceProvider::class,
 'PackageName' => DummyNamespace\DummyClassNameFacade::class,
 ```
 
-## Usage 
+## Usage
 
 ## License
 

--- a/tests/Commands/RootDirectoryFileContentTest.php
+++ b/tests/Commands/RootDirectoryFileContentTest.php
@@ -59,4 +59,48 @@ class RootDirectoryFileContentTest extends SkeletonCommandTest
 }";
         $this->assertEquals($composerJsonContent, file_get_contents('cleanique-coders/my-console/composer.json'));
     }
+
+    /** @test */
+    public function skeleton_command_creates_readme_md_file_with_correct_content()
+    {
+        $this->commandTester->execute([
+            'command' => $this->command->getName(),
+            'vendor'  => 'Cleanique Coders',
+            'package' => 'My Console',
+        ]);
+
+        $this->assertFileExists('cleanique-coders/my-console/README.md');
+
+        $readmeMdContent = "## About Your Package
+
+Tell people about your package
+
+## Installation
+
+1. In order to install PackageName in your Laravel project, just run the *composer require* command from your terminal:
+
+```
+composer require cleanique-coders/my-console
+```
+
+2. Then in your `config/app.php` add the following to the providers array:
+
+```php
+CleaniqueCoders\MyConsole\MyConsoleServiceProvider::class,
+```
+
+3. In the same `config/app.php` add the following to the aliases array:
+
+```php
+'PackageName' => CleaniqueCoders\MyConsole\MyConsoleFacade::class,
+```
+
+## Usage
+
+## License
+
+This package is open-sourced software licensed under the [MIT license](http://opensource.org/licenses/MIT).";
+
+        $this->assertEquals($readmeMdContent, file_get_contents('cleanique-coders/my-console/README.md'));
+    }
 }

--- a/tests/Commands/RootDirectoryFileContentTest.php
+++ b/tests/Commands/RootDirectoryFileContentTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace CleaniqueCoders\Console\Tests\Commands;
+
+use CleaniqueCoders\Console\Skeleton\MakeSkeletonCommand;
+use CleaniqueCoders\Console\Tests\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * Root directory file content test.
+ */
+class RootDirectoryFileContentTest extends TestCase
+{
+    protected $command;
+    protected $commandTester;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $application = new Application();
+        $application->add(new MakeSkeletonCommand());
+
+        // Setup the console command tester
+        $this->command = $application->find('skeleton');
+        $this->commandTester = new CommandTester($this->command);
+    }
+
+    public function tearDown()
+    {
+        // Remove all generated package directory and files
+        exec('rm -rf cleanique-coders');
+
+        parent::tearDown();
+    }
+
+    /** @test */
+    public function skeleton_command_creates_composer_json_file_with_correct_content()
+    {
+        $this->commandTester->execute([
+            'command' => $this->command->getName(),
+            'vendor'  => 'Cleanique Coders',
+            'package' => 'My Console',
+        ]);
+
+        $this->assertFileExists('cleanique-coders/my-console/composer.json');
+
+        $composerJsonContent = "{
+    \"name\": \"cleanique-coders/my-console\",
+    \"description\": \"Built with Laravel Standalone Package Creator\",
+    \"license\": \"MIT\",
+    \"authors\": [
+        {
+            \"name\": \"Nasrul Hazim\",
+            \"email\": \"nasrulhazim.m@gmail.com\"
+        }
+    ],
+    \"autoload\": {
+        \"psr-4\": {
+            \"CleaniqueCoders\\\\MyConsole\\\\\": \"src/\"
+        },
+        \"files\": [
+            \"src/Support/helpers.php\"
+        ]
+    },
+    \"autoload-dev\": {
+        \"psr-4\": {
+            \"CleaniqueCoders\\\\MyConsole\\\\Tests\\\\\": \"tests/\"
+        }
+    },
+    \"require\": {
+        \"illuminate/support\": \"^5.5\"
+    },
+    \"require-dev\": {
+        \"phpunit/phpunit\": \"^6.5\",
+        \"orchestra/testbench\": \"~3.0\",
+        \"codedungeon/phpunit-result-printer\": \"^0.4.4\"
+    },
+    \"config\": {
+        \"sort-packages\": true
+    },
+    \"minimum-stability\": \"dev\",
+    \"prefer-stable\": true
+}";
+        $this->assertEquals($composerJsonContent, file_get_contents('cleanique-coders/my-console/composer.json'));
+    }
+}

--- a/tests/Commands/RootDirectoryFileContentTest.php
+++ b/tests/Commands/RootDirectoryFileContentTest.php
@@ -2,39 +2,13 @@
 
 namespace CleaniqueCoders\Console\Tests\Commands;
 
-use CleaniqueCoders\Console\Skeleton\MakeSkeletonCommand;
-use CleaniqueCoders\Console\Tests\TestCase;
-use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 
 /**
  * Root directory file content test.
  */
-class RootDirectoryFileContentTest extends TestCase
+class RootDirectoryFileContentTest extends SkeletonCommandTest
 {
-    protected $command;
-    protected $commandTester;
-
-    public function setUp()
-    {
-        parent::setUp();
-
-        $application = new Application();
-        $application->add(new MakeSkeletonCommand());
-
-        // Setup the console command tester
-        $this->command = $application->find('skeleton');
-        $this->commandTester = new CommandTester($this->command);
-    }
-
-    public function tearDown()
-    {
-        // Remove all generated package directory and files
-        exec('rm -rf cleanique-coders');
-
-        parent::tearDown();
-    }
-
     /** @test */
     public function skeleton_command_creates_composer_json_file_with_correct_content()
     {

--- a/tests/Commands/SkeletonCommandTest.php
+++ b/tests/Commands/SkeletonCommandTest.php
@@ -8,9 +8,9 @@ use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 
 /**
- * Packager skeleton command test.
+ * Packager skeleton command base test.
  */
-class SkeletonCommandTest extends TestCase
+abstract class SkeletonCommandTest extends TestCase
 {
     protected $command;
     protected $commandTester;
@@ -33,62 +33,5 @@ class SkeletonCommandTest extends TestCase
         exec('rm -rf cleanique-coders');
 
         parent::tearDown();
-    }
-
-    /** @test */
-    public function skeleton_command_generates_files_with_correct_directory_and_file_names()
-    {
-        // Execute 'packager skeleton "Cleanique Coders" "My Console"' command
-        $this->commandTester->execute([
-            'command' => $this->command->getName(),
-            'vendor'  => 'Cleanique Coders',
-            'package' => 'My Console',
-        ]);
-
-        $output = $this->commandTester->getDisplay();
-
-        // Check for console command output
-        $this->assertContains('Your Laravel Package Skeleton is ready!', $output);
-
-        // Check that generated files are exist on /src directory
-        $this->assertFileExists('cleanique-coders/my-console/src/Support/helpers.php');
-        $this->assertFileExists('cleanique-coders/my-console/src/MyConsoleFacade.php');
-        $this->assertFileExists('cleanique-coders/my-console/src/MyConsoleServiceProvider.php');
-
-        // Check that generated files are exist on /tests directory
-        $this->assertFileExists('cleanique-coders/my-console/tests/TestCase.php');
-
-        // Check that generated files are exist on package root directory
-        $this->assertFileExists('cleanique-coders/my-console/.gitignore');
-        $this->assertFileExists('cleanique-coders/my-console/LICENSE.txt');
-        $this->assertFileExists('cleanique-coders/my-console/README.md');
-        $this->assertFileExists('cleanique-coders/my-console/composer.json');
-        $this->assertFileExists('cleanique-coders/my-console/phpunit.xml');
-    }
-
-    /** @test */
-    public function skeleton_command_checks_if_package_already_exists()
-    {
-        // Execute 'packager skeleton "Cleanique Coders" "My Console"' command
-        $this->commandTester->execute([
-            'command' => $this->command->getName(),
-            'vendor'  => 'Cleanique Coders',
-            'package' => 'My Console',
-        ]);
-
-        $output = $this->commandTester->getDisplay();
-
-        // Check for console command output
-        $this->assertContains('Your Laravel Package Skeleton is ready!', $output);
-
-        // Expect "PackageException" will thrown if same command executed.
-        $this->expectException('CleaniqueCoders\Console\Exceptions\PackageException');
-
-        // Execute same command second time
-        $this->commandTester->execute([
-            'command' => $this->command->getName(),
-            'vendor'  => 'Cleanique Coders',
-            'package' => 'My Console',
-        ]);
     }
 }

--- a/tests/Commands/SkeletonCommandTest.php
+++ b/tests/Commands/SkeletonCommandTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace CleaniqueCoders\Console\Tests\Commands;
+
+use CleaniqueCoders\Console\Skeleton\MakeSkeletonCommand;
+use CleaniqueCoders\Console\Tests\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * Packager skeleton command test.
+ */
+class SkeletonCommandTest extends TestCase
+{
+    protected $command;
+    protected $commandTester;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $application = new Application();
+        $application->add(new MakeSkeletonCommand());
+
+        // Setup the console command tester
+        $this->command = $application->find('skeleton');
+        $this->commandTester = new CommandTester($this->command);
+    }
+
+    public function tearDown()
+    {
+        // Remove all generated package directory and files
+        exec('rm -rf cleanique-coders');
+
+        parent::tearDown();
+    }
+
+    /** @test */
+    public function skeleton_command_generates_files_with_correct_directory_and_file_names()
+    {
+        // Execute 'packager skeleton "Cleanique Coders" "My Console"' command
+        $this->commandTester->execute([
+            'command' => $this->command->getName(),
+            'vendor'  => 'Cleanique Coders',
+            'package' => 'My Console',
+        ]);
+
+        $output = $this->commandTester->getDisplay();
+
+        // Check for console command output
+        $this->assertContains('Your Laravel Package Skeleton is ready!', $output);
+
+        // Check that generated files are exist on /src directory
+        $this->assertFileExists('cleanique-coders/my-console/src/Support/helpers.php');
+        $this->assertFileExists('cleanique-coders/my-console/src/MyConsoleFacade.php');
+        $this->assertFileExists('cleanique-coders/my-console/src/MyConsoleServiceProvider.php');
+
+        // Check that generated files are exist on /tests directory
+        $this->assertFileExists('cleanique-coders/my-console/tests/TestCase.php');
+
+        // Check that generated files are exist on package root directory
+        $this->assertFileExists('cleanique-coders/my-console/.gitignore');
+        $this->assertFileExists('cleanique-coders/my-console/LICENSE.txt');
+        $this->assertFileExists('cleanique-coders/my-console/README.md');
+        $this->assertFileExists('cleanique-coders/my-console/composer.json');
+        $this->assertFileExists('cleanique-coders/my-console/phpunit.xml');
+    }
+
+    /** @test */
+    public function skeleton_command_checks_if_package_already_exists()
+    {
+        // Execute 'packager skeleton "Cleanique Coders" "My Console"' command
+        $this->commandTester->execute([
+            'command' => $this->command->getName(),
+            'vendor'  => 'Cleanique Coders',
+            'package' => 'My Console',
+        ]);
+
+        $output = $this->commandTester->getDisplay();
+
+        // Check for console command output
+        $this->assertContains('Your Laravel Package Skeleton is ready!', $output);
+
+        // Expect "PackageException" will thrown if same command executed.
+        $this->expectException('CleaniqueCoders\Console\Exceptions\PackageException');
+
+        // Execute same command second time
+        $this->commandTester->execute([
+            'command' => $this->command->getName(),
+            'vendor'  => 'Cleanique Coders',
+            'package' => 'My Console',
+        ]);
+    }
+}

--- a/tests/Commands/SkeletonGeneratedFilesTest.php
+++ b/tests/Commands/SkeletonGeneratedFilesTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace CleaniqueCoders\Console\Tests\Commands;
+
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * Skeleton command generated files test.
+ */
+class SkeletonGeneratedFilesTest extends SkeletonCommandTest
+{
+    /** @test */
+    public function skeleton_command_generates_files_with_correct_directory_and_file_names()
+    {
+        // Execute 'packager skeleton "Cleanique Coders" "My Console"' command
+        $this->commandTester->execute([
+            'command' => $this->command->getName(),
+            'vendor'  => 'Cleanique Coders',
+            'package' => 'My Console',
+        ]);
+
+        $output = $this->commandTester->getDisplay();
+
+        // Check for console command output
+        $this->assertContains('Your Laravel Package Skeleton is ready!', $output);
+
+        // Check that generated files are exist on /src directory
+        $this->assertFileExists('cleanique-coders/my-console/src/Support/helpers.php');
+        $this->assertFileExists('cleanique-coders/my-console/src/MyConsoleFacade.php');
+        $this->assertFileExists('cleanique-coders/my-console/src/MyConsoleServiceProvider.php');
+
+        // Check that generated files are exist on /tests directory
+        $this->assertFileExists('cleanique-coders/my-console/tests/TestCase.php');
+
+        // Check that generated files are exist on package root directory
+        $this->assertFileExists('cleanique-coders/my-console/.gitignore');
+        $this->assertFileExists('cleanique-coders/my-console/LICENSE.txt');
+        $this->assertFileExists('cleanique-coders/my-console/README.md');
+        $this->assertFileExists('cleanique-coders/my-console/composer.json');
+        $this->assertFileExists('cleanique-coders/my-console/phpunit.xml');
+    }
+
+    /** @test */
+    public function skeleton_command_checks_if_package_already_exists()
+    {
+        // Execute 'packager skeleton "Cleanique Coders" "My Console"' command
+        $this->commandTester->execute([
+            'command' => $this->command->getName(),
+            'vendor'  => 'Cleanique Coders',
+            'package' => 'My Console',
+        ]);
+
+        $output = $this->commandTester->getDisplay();
+
+        // Check for console command output
+        $this->assertContains('Your Laravel Package Skeleton is ready!', $output);
+
+        // Expect "PackageException" will thrown if same command executed.
+        $this->expectException('CleaniqueCoders\Console\Exceptions\PackageException');
+
+        // Execute same command second time
+        $this->commandTester->execute([
+            'command' => $this->command->getName(),
+            'vendor'  => 'Cleanique Coders',
+            'package' => 'My Console',
+        ]);
+    }
+}

--- a/tests/Commands/SrcDirectoryFileContentTest.php
+++ b/tests/Commands/SrcDirectoryFileContentTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace CleaniqueCoders\Console\Tests\Commands;
+
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * Root directory file content test.
+ */
+class SrcDirectoryFileContentTest extends SkeletonCommandTest
+{
+    /** @test */
+    public function skeleton_command_creates_support_helper_file_with_correct_content()
+    {
+        $this->commandTester->execute([
+            'command' => $this->command->getName(),
+            'vendor'  => 'Cleanique Coders',
+            'package' => 'My Console',
+        ]);
+
+        $this->assertFileExists('cleanique-coders/my-console/src/Support/helpers.php');
+
+        $supportHelperPhpContent = "<?php\n";
+
+        $this->assertEquals($supportHelperPhpContent, file_get_contents('cleanique-coders/my-console/src/Support/helpers.php'));
+    }
+
+}


### PR DESCRIPTION
This package is a nice starting point for create a laravel package, thanks for creating this.

I have read a reference from this [symfony console documentation](https://symfony.com/doc/current/console.html#testing-commands) to make a console command test. I create a test case for this package. This PR contains a test case for the `skeleton` command. Could you please review this PR and merge to master branch?

Thank you.