### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
     },
     "require": {
         "guzzlehttp/guzzle": "^6.2",
-        "illuminate/filesystem": "^5.5",
-        "illuminate/support": "^5.5",
+        "illuminate/filesystem": "5.5.*",
+        "illuminate/support": "5.5.*",
         "symfony/console": "^3.2|~4.0",
         "symfony/filesystem": "^3.2|~4.0"
     },


### PR DESCRIPTION
Laravel doesn't follow semver. So having `^5.x`, `5.*` or `>=5.x` will mean that composer will install a future version even though that version breaks the package.