### PR TITLE
Update .travis.yml to use php7.0 for paralel travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 language: php
 
 php:
+  - 7.0
   - 7.1
 
 before_script:
   - travis_retry composer self-update
-  - travis_retry composer install --prefer-source --no-interaction --dev
+  - travis_retry composer update --prefer-source --no-interaction --dev
 
 script:
   - vendor/bin/phpunit


### PR DESCRIPTION
A small update for `.travis.yml` file to get PHP 7.0 environment on paralel travis build.

Here is a screen capture for build and test that passed for PHP 7.0.

![shutter_20180104-010](https://user-images.githubusercontent.com/8721551/34563373-5e8278e8-f18d-11e7-9b55-1111d12c9f57.jpg)
